### PR TITLE
Fix issue preventing find_duplicates delete from working because of missing IDs

### DIFF
--- a/lib/rearmed_rails/monkey_patches/active_record.rb
+++ b/lib/rearmed_rails/monkey_patches/active_record.rb
@@ -122,7 +122,11 @@ if defined?(ActiveRecord)
             attrs = d.attributes.slice(*options[:columns].collect(&:to_s))
             current_duplicates = self.where(attrs)
             
-            current_duplicates.offset(options[:delete][:keep] == :first ? 1 : 0).limit(options[:delete][:keep] == :first ? current_duplicates.size : current_duplicates.size - 1).pluck(:id)
+            if options[:delete][:keep] == :first
+              current_duplicates.offset(1).pluck(:id)
+            else
+              current_duplicates.limit(current_duplicates.size - 1).pluck(:id)
+            end
           end
 
           duplicates = self.where(id: duplicate_ids)


### PR DESCRIPTION
This fixes #2. Using `keep = :first` is faster than using `:last` because it doesn't need to get the `count` of the duplicates before selecting the `id`s. 